### PR TITLE
ci: fetch tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,6 +46,13 @@ steps:
   environment:
     CODECOV_TOKEN:
       from_secret: codecov_token
+- name: fetch tags
+  image: plugins/git
+  commands:
+  - git fetch --tags
+  when:
+    event:
+    - tag
 - name: release
   image: &goreleaser goreleaser/goreleaser:v0.105.0
   commands:


### PR DESCRIPTION
Fix release error

https://cloud.drone.io/suzuki-shunsuke/akoi/86/2/5

```
release failed after 0.01s error=git doesn't contain any tags. Either add a tag or use --snapshot
```

https://docs.drone.io/user-guide/pipeline/cloning/